### PR TITLE
Feat: 관리자의 role별 유저 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/zipsa/controller/AdminController.java
+++ b/src/main/java/com/sparta/zipsa/controller/AdminController.java
@@ -18,16 +18,16 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    //전체 사용자 조회
+    //요청된 Role에 따라 해당 Role의 사용자 전체 조회
     @GetMapping("/users")
     @ResponseStatus(HttpStatus.OK)
-    public Page<User> getUserAll(
+    public Page<User> getUserAllByRoll(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
-            @RequestParam("sortBy") String sortBy,
-            @RequestParam("isAsc") boolean isAsc
+            @RequestParam("isAsc") boolean isAsc,
+            @RequestParam("role") String role
             ) {
-        return adminService.getUserAll(page, size, sortBy, isAsc);
+        return adminService.getUserAllByRole(page, size, isAsc, role);
     }
 
 }

--- a/src/main/java/com/sparta/zipsa/service/admin/AdminService.java
+++ b/src/main/java/com/sparta/zipsa/service/admin/AdminService.java
@@ -4,5 +4,5 @@ import com.sparta.zipsa.entity.User;
 import org.springframework.data.domain.Page;
 
 public interface AdminService {
-    Page<User> getUserAll(int page, int size, String sortBy, boolean isAsc);
+    Page<User> getUserAllByRole(int page, int size, boolean isAsc, String role);
 }

--- a/src/main/java/com/sparta/zipsa/service/admin/AdminServiceImpl.java
+++ b/src/main/java/com/sparta/zipsa/service/admin/AdminServiceImpl.java
@@ -18,15 +18,21 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<User> getUserAll(int page, int size, String sortBy, boolean isAsc) {
+    public Page<User> getUserAllByRole(int page, int size, boolean isAsc, String role) {
         //페이징 처리
         //삼항연산자로 true ASC / false DESC 정렬 설정
-        //sortBy로 정렬 기준이 되는 property 설정
+        //sortBy로 정렬 기준이 되는 property 설정 - id
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
-        Sort sort = Sort.by(direction, sortBy);
+        Sort sort = Sort.by(direction, "id");
         Pageable pageable = PageRequest.of(page, size, sort);
 
-        Page<User> users = userRepository.findAll(pageable);
+        if (role.equals("customer")) {
+            Page<User> users = userRepository.findByUserRoleEnum(pageable, UserRoleEnum.CUSTOMER);
+        } else if (role.equals("helper")) {
+            Page<User> users = userRepository.findByUserRoleEnum(pageable, UserRoleEnum.HELPER);
+        } else if (role.equals("admin")) {
+            Page<User> users = userRepository.findByUserRoleEnum(pageable, UserRoleEnum.ADMIN);
+        } else throw new IllegalArgumentException();
 
         return users;
     }


### PR DESCRIPTION
기존의 관리자의 전체 유저 조회 기능을 파라미터값으로 받은 role에 따라 조회되는 유저의 타입이 달라지도록 구현했습니다.
전체 유저 조회 -> requestparam의 role 입력값에 따라 해당 role의 유저 전체 조회