### PR TITLE
Feat: 관리자의 helper 신청글 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/zipsa/controller/AdminController.java
+++ b/src/main/java/com/sparta/zipsa/controller/AdminController.java
@@ -30,4 +30,11 @@ public class AdminController {
         return adminService.getUserAllByRole(page, size, isAsc, role);
     }
 
+    //helper 신청글 조회
+    @GetMapping("/helperboard")
+    @ResponseStatus(HttpStatus.OK)
+    public List<HelperBoard> getHelperBoard() {
+        return adminService.getHelperBoard();
+    }
+
 }

--- a/src/main/java/com/sparta/zipsa/service/admin/AdminService.java
+++ b/src/main/java/com/sparta/zipsa/service/admin/AdminService.java
@@ -5,4 +5,5 @@ import org.springframework.data.domain.Page;
 
 public interface AdminService {
     Page<User> getUserAllByRole(int page, int size, boolean isAsc, String role);
+    List<HelperBoard> getHelperBoard();
 }

--- a/src/main/java/com/sparta/zipsa/service/admin/AdminServiceImpl.java
+++ b/src/main/java/com/sparta/zipsa/service/admin/AdminServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminServiceImpl implements AdminService {
 
     private final UserRepository userRepository;
+    private final HelperBoardRepository helperBoardRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -35,5 +36,12 @@ public class AdminServiceImpl implements AdminService {
         } else throw new IllegalArgumentException();
 
         return users;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<HelperBoard> getHelperBoard() {
+        List<HelperBoard> helperBoardList = helperBoardRepository.findAll();
+        return helperBoardList;
     }
 }


### PR DESCRIPTION
관리자의 helper 신청글을 조회하는 기능을 구현했습니다.
현재 dto에 담지 않고 그대로 HelperBoard를 리스트에 담아서 반환합니다.
이 부분은 나중에 수정하겠습니다.